### PR TITLE
fix: improve handling of default export statements

### DIFF
--- a/_util.ts
+++ b/_util.ts
@@ -1,0 +1,20 @@
+/**
+ * Roughly search for export default declaration
+ * @return `true` if `code` has default export statement(s).
+ */
+export function hasDefaultExport(code: string): boolean {
+  if (/export[\s\t]*default[\s\t]/.test(code)) {
+    return true;
+  }
+
+  const match = code.match(/export[\s\t]*{([^}]*)}/);
+  if (match) {
+    // Check if "default" exists in the list
+    return match[1].split(",").some((entry) => {
+      entry = entry.trim();
+      return entry === "default" || /[\s\t]+as[\s\t]+default$/.test(entry);
+    });
+  }
+
+  return false;
+}

--- a/_util_test.ts
+++ b/_util_test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { hasDefaultExport } from "./_util.ts";
+const { test } = Deno;
+
+test("hasDefaultExport", () => {
+  for (
+    const { want, input } of [
+      {
+        want: true,
+        input: `export default from "https://deno.land/foo/bar.ts"`,
+      },
+      {
+        want: true,
+        input: `export { default } from "https://deno.land/foo/bar.ts"`,
+      },
+      {
+        want: true,
+        input: `export{default}from "https://deno.land/foo/bar.ts"`,
+      },
+      {
+        want: false,
+        input:
+          `export { assert } from "https://deno.land/std/testing/asserts.ts"`,
+      },
+      {
+        want: true,
+        input: `export { foo, default } from "https://deno.land/foo/bar.ts"`,
+      },
+      {
+        want: false,
+        input: `export { defaultValue } from "https://deno.land/foo/bar.ts"`,
+      },
+      {
+        want: true,
+        input: `export { bar as default } from "https://deno.land/foo/bar.ts"`,
+      },
+    ]
+  ) {
+    const got = hasDefaultExport(input);
+    assertEquals(
+      got,
+      want,
+      `Given "${input}", hasDefaultExport should return ${want}`,
+    );
+  }
+});

--- a/dlink.ts
+++ b/dlink.ts
@@ -4,6 +4,7 @@ import { exists } from "./vendor/https/deno.land/std/fs/exists.ts";
 import * as flags from "./vendor/https/deno.land/std/flags/mod.ts";
 import { sprintf } from "./vendor/https/deno.land/std/fmt/printf.ts";
 import { gray, green, red } from "./vendor/https/deno.land/std/fmt/colors.ts";
+import * as util from "./_util.ts";
 const VERSION = "0.8.7";
 
 export type Module = {
@@ -151,8 +152,7 @@ async function writeLinkFiles({
       throw new Error(`too big source file: ${contentLength}bytes`);
     }
     const code = await resp.text();
-    // Roughly search for export default declaration
-    const hasDefaultExport = !!code.match(/export[\s\t]*default[\s\t]/);
+    const hasDefaultExport = util.hasDefaultExport(code);
     let typeDefinition: string | undefined;
     if (typeFile) {
       if (typeFile.match(/^(file|https?):\/\//) || typeFile.startsWith("/")) {


### PR DESCRIPTION
Some CDNs use `export { default } from "..."` form instead of `export default from "..."`. (e.g. https://cdn.skypack.dev/lodash-es@4.17.21/sample.js)
This PR adds support for such CDNs.